### PR TITLE
Added an overloaded method for scanFile which takes an InputStream

### DIFF
--- a/src/main/java/com/kanishka/virustotalv2/VirustotalPublicV2.java
+++ b/src/main/java/com/kanishka/virustotalv2/VirustotalPublicV2.java
@@ -50,6 +50,15 @@ public interface VirustotalPublicV2 {
     ScanInfo scanFile(final InputStream fileToScan) throws IOException, UnauthorizedAccessException, QuotaExceededException;
 
     /**
+     * Scan a given single file from an input stream
+     *
+     * @param fileToScan the file object to be scanned from the InputStream
+     * @param fileName the name of the file to be scanned
+     * @return scan information
+     */
+    ScanInfo scanFile(final InputStream fileToScan, String fileName) throws IOException, UnauthorizedAccessException, QuotaExceededException;
+
+    /**
      * The call allows you to rescan files in VirusTotal's file store without having to resubmit them, thus saving bandwidth.
      * <p/>
      * The VirusTotal public API allows you to rescan files that you or other users already sent in the past and, hence,

--- a/src/main/java/com/kanishka/virustotalv2/VirustotalPublicV2.java
+++ b/src/main/java/com/kanishka/virustotalv2/VirustotalPublicV2.java
@@ -15,6 +15,7 @@ import com.kanishka.virustotal.exception.UnauthorizedAccessException;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * @author kdkanishka@gmail.com
@@ -39,6 +40,14 @@ public interface VirustotalPublicV2 {
      * @return scan information
      */
     ScanInfo scanFile(final File fileToScan) throws IOException, UnauthorizedAccessException, QuotaExceededException;
+
+    /**
+     * Scan a given single file from an input stream
+     *
+     * @param fileToScan the file object to be scanned from the InputStream
+     * @return scan information
+     */
+    ScanInfo scanFile(final InputStream fileToScan) throws IOException, UnauthorizedAccessException, QuotaExceededException;
 
     /**
      * The call allows you to rescan files in VirusTotal's file store without having to resubmit them, thus saving bandwidth.

--- a/src/main/java/com/kanishka/virustotalv2/VirustotalPublicV2Impl.java
+++ b/src/main/java/com/kanishka/virustotalv2/VirustotalPublicV2Impl.java
@@ -122,7 +122,7 @@ public class VirustotalPublicV2Impl implements VirustotalPublicV2 {
         InputStream inputStream = null;
         try {
            inputStream = new FileInputStream(fileToScan);
-           scanInfo = scanFile(inputStream);
+           scanInfo = scanFile(inputStream, fileToScan.getName());
         }
         finally {
             if (inputStream != null) {
@@ -137,10 +137,17 @@ public class VirustotalPublicV2Impl implements VirustotalPublicV2 {
     public ScanInfo scanFile(InputStream inputStream) throws
         IOException, UnauthorizedAccessException,
         QuotaExceededException {
+      return scanFile(inputStream, null);
+    }
+
+    @Override
+    public ScanInfo scanFile(InputStream inputStream, String fileName) throws
+        IOException, UnauthorizedAccessException,
+        QuotaExceededException {
         Response responseWrapper = new Response();
         ScanInfo scanInfo = new ScanInfo();
 
-        InputStreamBody inputStreamBody = new InputStreamBody(inputStream, ContentType.APPLICATION_OCTET_STREAM.toString(), null);
+        InputStreamBody inputStreamBody = new InputStreamBody(inputStream, ContentType.APPLICATION_OCTET_STREAM.toString(), fileName != null ? fileName : "file");
         MultiPartEntity file = new MultiPartEntity("file", inputStreamBody);
         MultiPartEntity apikey = new MultiPartEntity(API_KEY_FIELD,
                 new StringBody(apiKey));

--- a/src/main/java/com/kanishka/virustotalv2/VirustotalPublicV2Impl.java
+++ b/src/main/java/com/kanishka/virustotalv2/VirustotalPublicV2Impl.java
@@ -20,12 +20,17 @@ import com.kanishka.virustotal.exception.APIKeyNotFoundException;
 import com.kanishka.virustotal.exception.InvalidArguentsException;
 import com.kanishka.virustotal.exception.QuotaExceededException;
 import com.kanishka.virustotal.exception.UnauthorizedAccessException;
+
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.content.FileBody;
+import org.apache.http.entity.mime.content.InputStreamBody;
 import org.apache.http.entity.mime.content.StringBody;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
@@ -110,14 +115,33 @@ public class VirustotalPublicV2Impl implements VirustotalPublicV2 {
     public ScanInfo scanFile(File fileToScan) throws
             IOException, UnauthorizedAccessException,
             QuotaExceededException {
+        ScanInfo scanInfo = new ScanInfo();
         if (!fileToScan.canRead()) {
             throw new FileNotFoundException(ERR_MSG_FILE_NOT_FOUND);
         }
+        InputStream inputStream = null;
+        try {
+           inputStream = new FileInputStream(fileToScan);
+           scanInfo = scanFile(inputStream);
+        }
+        finally {
+            if (inputStream != null) {
+                inputStream.close();
+            }
+        }
+
+        return  scanInfo;
+    }
+
+    @Override
+    public ScanInfo scanFile(InputStream inputStream) throws
+        IOException, UnauthorizedAccessException,
+        QuotaExceededException {
         Response responseWrapper = new Response();
         ScanInfo scanInfo = new ScanInfo();
 
-        FileBody fileBody = new FileBody(fileToScan);
-        MultiPartEntity file = new MultiPartEntity("file", fileBody);
+        InputStreamBody inputStreamBody = new InputStreamBody(inputStream, ContentType.APPLICATION_OCTET_STREAM.toString(), null);
+        MultiPartEntity file = new MultiPartEntity("file", inputStreamBody);
         MultiPartEntity apikey = new MultiPartEntity(API_KEY_FIELD,
                 new StringBody(apiKey));
         List<MultiPartEntity> multiParts = new ArrayList<MultiPartEntity>();


### PR DESCRIPTION
Added an overloaded method for scanFile which takes an InputStream instead of a File object so that operations can be done in memory.  I
modified the existing File api to call the InputStream api So code
coverage is still handled by the tests which invoke the File API.